### PR TITLE
Convert gitlab-source-group/source-gitlab-input to GitHub Actions

### DIFF
--- a/.github/workflows/source-gitlab-input.yml
+++ b/.github/workflows/source-gitlab-input.yml
@@ -1,0 +1,33 @@
+name: gitlab-source-group/source-gitlab-input
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  ENVIRONMENT: demo-env
+jobs:
+  build_job:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DEPLOY_ENV: dev
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Building for $DEPLOY_ENV"
+  deploy_job:
+    needs: build_job
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DEPLOY_ENV: dev
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - run: echo "Deploying to $ENVIRONMENT environment"


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/gitlab-source-group/source-gitlab-input) :tada: